### PR TITLE
Feat: 박람회 정보 조회 수정 및 배너 신청,조회,수정 기능 구현

### DIFF
--- a/eventory-server/src/main/java/com/eventory/common/entity/Banner.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/Banner.java
@@ -1,7 +1,9 @@
 package com.eventory.common.entity;
 
+import com.eventory.expoAdmin.dto.BannerUpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -12,6 +14,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity(name = "banner")
@@ -29,7 +32,7 @@ public class Banner {
     private Expo expo;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payment_id", nullable = false)
+    @JoinColumn(name = "payment_id", nullable = true)
     private Payment payment;
 
     @Column(name = "image_url", length = 255, nullable = false)
@@ -55,4 +58,10 @@ public class Banner {
 
     @Column(name = "reason", length = 255, nullable = true)
     private String reason;
+
+    public void updateBanner(BannerUpdateRequestDto requestDto) {
+        this.imageUrl = requestDto.getImageUrl();
+        this.startDate = requestDto.getStartDate();
+        this.endDate = requestDto.getEndDate();
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/common/entity/Booth.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/Booth.java
@@ -31,6 +31,10 @@ public class Booth {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @OneToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "payment_id", nullable = true)
+    private Payment payment;
+
     @Column(name = "title", length = 255, nullable = false)
     private String title;
 
@@ -61,7 +65,7 @@ public class Booth {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 255)
+    @Column(name = "status", length = 255, nullable = false)
     private BoothStatus status;
 
     @Column(name = "reason", length = 255, nullable = true)

--- a/eventory-server/src/main/java/com/eventory/common/entity/Expo.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/Expo.java
@@ -1,5 +1,6 @@
 package com.eventory.common.entity;
 
+import com.eventory.expoAdmin.dto.ExpoRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,7 +29,7 @@ public class Expo {
     private Long expoId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "expo_admin_id", nullable = false)
+    @JoinColumn(name = "expo_admin_id", nullable = true)
     private ExpoAdmin expoAdmin;
 
     @Column(name = "title", length = 255, nullable = false)
@@ -82,4 +83,12 @@ public class Expo {
         return expoCategories.isEmpty() ? null : expoCategories.get(0).getCategory();
     }
 
+    public void updateExpo(ExpoRequestDto requestDto) {
+        this.title = requestDto.getTitle();
+        this.imageUrl = requestDto.getImageUrl();
+        this.description = requestDto.getDescription();
+        this.startDate = requestDto.getStartDate();
+        this.endDate = requestDto.getEndDate();
+        this.visibility = requestDto.getVisibility();
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/common/entity/ExpoAdmin.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/ExpoAdmin.java
@@ -1,5 +1,6 @@
 package com.eventory.common.entity;
 
+import com.eventory.expoAdmin.dto.ManagerRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -49,4 +50,10 @@ public class ExpoAdmin {
     @UpdateTimestamp
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime updatedAt;
+
+    public void updateExpoAdmin(ManagerRequestDto requestDto) {
+        this.name = requestDto.getName();
+        this.email = requestDto.getEmail();
+        this.phone = requestDto.getPhone();
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/common/entity/QrCode.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/QrCode.java
@@ -31,7 +31,7 @@ public class QrCode {
     private String data;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 255)
+    @Column(name = "status", length = 255, nullable = false)
     private QrCodeStatus status;
 
     @CreationTimestamp

--- a/eventory-server/src/main/java/com/eventory/common/entity/Refund.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/Refund.java
@@ -1,5 +1,6 @@
 package com.eventory.common.entity;
 
+import com.eventory.expoAdmin.dto.RefundRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,11 +38,11 @@ public class Refund {
     @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "approved_at", columnDefinition = "TIMESTAMP")
+    @Column(name = "approved_at", columnDefinition = "TIMESTAMP", nullable = true)
     private LocalDateTime approvedAt;
 
-    public void updateStatus(RefundStatus status, String reason) {
-        this.status = status;
-        this.reason = reason;
+    public void updateStatus(RefundRequestDto requestDto) {
+        this.status = requestDto.getStatus();
+        this.reason = requestDto.getReason();
     }
 }

--- a/eventory-server/src/main/java/com/eventory/common/entity/Reservation.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/Reservation.java
@@ -36,7 +36,7 @@ public class Reservation {
     private Payment payment;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 255)
+    @Column(name = "status", length = 255, nullable = false)
     private ReservationStatus status;
 
     @Column(name = "code", length = 255, nullable = false)

--- a/eventory-server/src/main/java/com/eventory/common/entity/User.java
+++ b/eventory-server/src/main/java/com/eventory/common/entity/User.java
@@ -42,31 +42,31 @@ public class User {
     @Column(name = "password", length = 255, nullable = false)
     private String password;
 
-    @Column(name = "birth", length = 255)
+    @Column(name = "birth", length = 255, nullable = true)
     private LocalDate birth;
 
-    @Column(name = "gender", length = 10)
+    @Column(name = "gender", length = 10, nullable = true)
     private String gender;
 
     @Column(name = "phone", length = 255, nullable = false)
     private String phone;
 
-    @Column(name = "company_name_kr", length = 255)
+    @Column(name = "company_name_kr", length = 255, nullable = true)
     private String companyNameKr;
 
-    @Column(name = "company_name_eng", length = 255)
+    @Column(name = "company_name_eng", length = 255, nullable = true)
     private String companyNameEng;
 
-    @Column(name = "ceo_name_kr", length = 255)
+    @Column(name = "ceo_name_kr", length = 255, nullable = true)
     private String ceoNameKr;
 
-    @Column(name = "ceo_name_eng", length = 255)
+    @Column(name = "ceo_name_eng", length = 255, nullable = true)
     private String ceoNameEng;
 
-    @Column(name = "company_address", length = 255)
+    @Column(name = "company_address", length = 255, nullable = true)
     private String companyAddress;
 
-    @Column(name = "registration_num", length = 255)
+    @Column(name = "registration_num", length = 255, nullable = true)
     private String registrationNum;
 
     @CreationTimestamp

--- a/eventory-server/src/main/java/com/eventory/common/exception/CustomErrorCode.java
+++ b/eventory-server/src/main/java/com/eventory/common/exception/CustomErrorCode.java
@@ -39,14 +39,17 @@ public enum CustomErrorCode {
 
 	// 박람회 E
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "카테고리가 존재하지 않습니다"),
+
     // 박람회 관리자 D
     INVALID_PERIOD(HttpStatus.BAD_REQUEST, "D001", "유효하지 않은 통계 기간입니다."),
     EXPO_NOT_FOUND(HttpStatus.NOT_FOUND, "D002", "해당 박람회를 찾을 수 없습니다."),
     INVALID_ID(HttpStatus.BAD_REQUEST, "D003", "유효하지 않은 식별자입니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "D004", "유효하지 않은 날짜 구간입니다."),
     REPORT_EXPORT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "D005", "리포트 내보내기에 실패했습니다."),
-    TICKET_TYPE_STATS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "D006", "티켓 타입 통계 집계 중 오류가 발생했습니다.");
+    TICKET_TYPE_STATS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "D006", "티켓 타입 통계 집계 중 오류가 발생했습니다."),
 
+    // 박람회 관리자 마이페이지 P
+    NOT_FOUND_MANAGER(HttpStatus.NOT_FOUND, "P001", "해당 박람회 담당자를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/eventory-server/src/main/java/com/eventory/common/exception/CustomErrorCode.java
+++ b/eventory-server/src/main/java/com/eventory/common/exception/CustomErrorCode.java
@@ -50,7 +50,9 @@ public enum CustomErrorCode {
     NOT_FOUND_EXPO_ADMIN(HttpStatus.NOT_FOUND, "D007", "박람회 관리자 계정을 찾을 수 없습니다"),
 
     // 박람회 관리자 마이페이지 P
-    NOT_FOUND_MANAGER(HttpStatus.NOT_FOUND, "P001", "해당 박람회 담당자를 찾을 수 없습니다.");
+    NOT_FOUND_MANAGER(HttpStatus.NOT_FOUND, "P001", "해당 박람회 담당자를 찾을 수 없습니다."),
+    NOT_FOUND_EXPO(HttpStatus.NOT_FOUND, "P002", "해당 박람회를 찾을 수 없습니다."),
+    NOT_FOUND_BANNER(HttpStatus.NOT_FOUND, "P003", "해당 배너를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/eventory-server/src/main/java/com/eventory/common/exception/CustomErrorCode.java
+++ b/eventory-server/src/main/java/com/eventory/common/exception/CustomErrorCode.java
@@ -47,6 +47,7 @@ public enum CustomErrorCode {
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "D004", "유효하지 않은 날짜 구간입니다."),
     REPORT_EXPORT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "D005", "리포트 내보내기에 실패했습니다."),
     TICKET_TYPE_STATS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "D006", "티켓 타입 통계 집계 중 오류가 발생했습니다."),
+    NOT_FOUND_EXPO_ADMIN(HttpStatus.NOT_FOUND, "D007", "박람회 관리자 계정을 찾을 수 없습니다"),
 
     // 박람회 관리자 마이페이지 P
     NOT_FOUND_MANAGER(HttpStatus.NOT_FOUND, "P001", "해당 박람회 담당자를 찾을 수 없습니다.");

--- a/eventory-server/src/main/java/com/eventory/common/repository/BannerRepository.java
+++ b/eventory-server/src/main/java/com/eventory/common/repository/BannerRepository.java
@@ -1,0 +1,13 @@
+package com.eventory.common.repository;
+
+import com.eventory.common.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+    Optional<Banner> findByExpo_ExpoId(@Param("expoId") Long expoId);
+}

--- a/eventory-server/src/main/java/com/eventory/common/repository/ExpoRepository.java
+++ b/eventory-server/src/main/java/com/eventory/common/repository/ExpoRepository.java
@@ -1,12 +1,19 @@
 package com.eventory.common.repository;
 
 import com.eventory.common.entity.Expo;
+import com.eventory.common.entity.ExpoStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ExpoRepository extends JpaRepository<Expo, Long> {
-    List<Expo> findByExpoAdmin_ExpoAdminIdOrderByTitleAsc(Long expoAdminId);
+
+    @Query("SELECT e FROM expo e " +
+            "WHERE e.expoAdmin.expoAdminId = :expoAdminId " +
+            "AND e.status = :status " +
+            "ORDER BY e.title ASC")
+    List<Expo> findByExpoAdminIdAndStatusOrderByTitleAsc(Long expoAdminId, ExpoStatus status);
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
@@ -161,7 +161,7 @@ public class ExpoAdminController {
     }
 
     // 박람회 담당자 정보 조회
-    /*@GetMapping("/profile")
+    @GetMapping("/profile")
     public ResponseEntity<ManagerResponseDto> findExpoManagerInfo(@AuthenticationPrincipal ExpoAdmin expoAdmin) {
         Long expoAdminId = expoAdmin.getExpoAdminId();
         ManagerResponseDto responseDto = expoInfoService.findExpoManagerInfo(expoAdminId);
@@ -209,5 +209,5 @@ public class ExpoAdminController {
     public ResponseEntity<Void> updateExpoBanner(@PathVariable Long expoId, @Valid @RequestBody BannerUpdateRequestDto requestDto) {
         expoInfoService.updateExpoBanner(expoId, requestDto);
         return ResponseEntity.ok().build();
-    }*/
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
@@ -32,8 +32,7 @@ public class ExpoAdminController {
     // 해당 박람회 관리자에 속하는 전체 박람회 목록
     @GetMapping("/expos")
     public ResponseEntity<List<ExpoResponseDto>> findAllExpos(@AuthenticationPrincipal ExpoAdmin expoAdmin) {
-        Long expoAdminId = expoAdmin.getExpoAdminId();
-        List<ExpoResponseDto> expos = expoAdminService.findAllExpos(expoAdminId);
+        List<ExpoResponseDto> expos = expoAdminService.findAllExpos(expoAdmin);
         return ResponseEntity.ok(expos);
     }
 
@@ -162,7 +161,7 @@ public class ExpoAdminController {
     }
 
     // 박람회 담당자 정보 조회
-    @GetMapping("/profile")
+    /*@GetMapping("/profile")
     public ResponseEntity<ManagerResponseDto> findExpoManagerInfo(@AuthenticationPrincipal ExpoAdmin expoAdmin) {
         Long expoAdminId = expoAdmin.getExpoAdminId();
         ManagerResponseDto responseDto = expoInfoService.findExpoManagerInfo(expoAdminId);
@@ -210,5 +209,5 @@ public class ExpoAdminController {
     public ResponseEntity<Void> updateExpoBanner(@PathVariable Long expoId, @Valid @RequestBody BannerUpdateRequestDto requestDto) {
         expoInfoService.updateExpoBanner(expoId, requestDto);
         return ResponseEntity.ok().build();
-    }
+    }*/
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
@@ -1,12 +1,14 @@
 package com.eventory.expoAdmin.controller;
 
-import com.eventory.common.entity.User;
+import com.eventory.common.entity.ExpoAdmin;
 import com.eventory.common.exception.CustomErrorCode;
 import com.eventory.common.exception.CustomException;
 import com.eventory.expoAdmin.dto.*;
 import com.eventory.expoAdmin.service.ExpoAdminService;
+import com.eventory.expoAdmin.service.ExpoInfoService;
 import com.eventory.expoAdmin.service.SalesAdminService;
 import com.eventory.expoAdmin.web.FileResponseUtils;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -25,11 +27,12 @@ public class ExpoAdminController {
 
     private final ExpoAdminService expoAdminService;
     private final SalesAdminService salesAdminService;
+    private final ExpoInfoService expoInfoService;
 
     // 해당 박람회 관리자에 속하는 전체 박람회 목록
     @GetMapping("/expos")
-    public ResponseEntity<List<ExpoResponseDto>> findAllExpos(@AuthenticationPrincipal User user) {
-        Long expoAdminId = user.getUserId();
+    public ResponseEntity<List<ExpoResponseDto>> findAllExpos(@AuthenticationPrincipal ExpoAdmin expoAdmin) {
+        Long expoAdminId = expoAdmin.getExpoAdminId();
         List<ExpoResponseDto> expos = expoAdminService.findAllExpos(expoAdminId);
         return ResponseEntity.ok(expos);
     }
@@ -101,7 +104,7 @@ public class ExpoAdminController {
 
     // 환불 상태 변경
     @PatchMapping("/refund/{refundId}/status")
-    public ResponseEntity<Void> updateRefundStatus(@PathVariable Long refundId, @RequestBody RefundRequestDto request) {
+    public ResponseEntity<Void> updateRefundStatus(@PathVariable Long refundId, @Valid @RequestBody RefundRequestDto request) {
         salesAdminService.updateRefundStatus(refundId, request);
         return ResponseEntity.ok().build();
     }
@@ -160,43 +163,52 @@ public class ExpoAdminController {
 
     // 박람회 담당자 정보 조회
     @GetMapping("/profile")
-    public ResponseEntity<ManagerResponseDto> findExpoManagerInfo() {
-
+    public ResponseEntity<ManagerResponseDto> findExpoManagerInfo(@AuthenticationPrincipal ExpoAdmin expoAdmin) {
+        Long expoAdminId = expoAdmin.getExpoAdminId();
+        ManagerResponseDto responseDto = expoInfoService.findExpoManagerInfo(expoAdminId);
+        return ResponseEntity.ok(responseDto);
     }
 
     // 박람회 담당자 정보 수정
     @PutMapping("/profile")
-    public ResponseEntity<ManagerResponseDto> updateExpoManagerInfo() {
-
+    public ResponseEntity<Void> updateExpoManagerInfo(@AuthenticationPrincipal ExpoAdmin expoAdmin, @Valid @RequestBody ManagerRequestDto requestDto) {
+        Long expoAdminId = expoAdmin.getExpoAdminId();
+        expoInfoService.updateExpoManagerInfo(expoAdminId, requestDto);
+        return ResponseEntity.ok().build();
     }
 
     // 특정 박람회 정보 조회
     @GetMapping("/expos/{expoId}")
-    public ResponseEntity<ExpoResponseDto> findExpoInfo() {
-
+    public ResponseEntity<ExpoResponseDto> findExpoInfo(@PathVariable Long expoId) {
+        ExpoResponseDto responseDto = expoInfoService.findExpoInfo(expoId);
+        return ResponseEntity.ok(responseDto);
     }
 
     // 특정 박람회 정보 수정
     @PutMapping("/expos/{expoId}")
-    public ResponseEntity<ExpoResponseDto> updateExpoInfo() {
-
+    public ResponseEntity<Void> updateExpoInfo(@PathVariable Long expoId, @Valid @RequestBody ExpoRequestDto requestDto) {
+        expoInfoService.updateExpoInfo(expoId, requestDto);
+        return ResponseEntity.ok().build();
     }
 
     // 특정 박람회 배너 신청
-    @PostMapping("expos/{expoId}/banner")
-    public ResponseEntity<BannerResponseDto> createExpoBanner() {
-
+    @PostMapping("/expos/{expoId}/banner")
+    public ResponseEntity<Void> createExpoBanner(@PathVariable Long expoId, @Valid @RequestBody BannerCreateRequestDto requestDto) {
+        expoInfoService.createExpoBanner(expoId, requestDto);
+        return ResponseEntity.ok().build();
     }
 
     // 특정 박람회 배너 조회
-    @GetMapping("expos/{expoId}/banner")
-    public ResponseEntity<BannerResponseDto> findExpoBanner() {
-
+    @GetMapping("/expos/{expoId}/banner")
+    public ResponseEntity<BannerResponseDto> findExpoBanner(@PathVariable Long expoId) {
+        BannerResponseDto responseDto = expoInfoService.findExpoBanner(expoId);
+        return ResponseEntity.ok(responseDto);
     }
 
     // 특정 박람회 배너 수정
-    @PutMapping("expos/{expoId}/banner")
-    public ResponseEntity<BannerResponseDto> updateExpoBanner() {
-
+    @PutMapping("/expos/{expoId}/banner")
+    public ResponseEntity<Void> updateExpoBanner(@PathVariable Long expoId, @Valid @RequestBody BannerUpdateRequestDto requestDto) {
+        expoInfoService.updateExpoBanner(expoId, requestDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/controller/ExpoAdminController.java
@@ -158,4 +158,45 @@ public class ExpoAdminController {
         return ResponseEntity.ok(ratios);
     }
 
+    // 박람회 담당자 정보 조회
+    @GetMapping("/profile")
+    public ResponseEntity<ManagerResponseDto> findExpoManagerInfo() {
+
+    }
+
+    // 박람회 담당자 정보 수정
+    @PutMapping("/profile")
+    public ResponseEntity<ManagerResponseDto> updateExpoManagerInfo() {
+
+    }
+
+    // 특정 박람회 정보 조회
+    @GetMapping("/expos/{expoId}")
+    public ResponseEntity<ExpoResponseDto> findExpoInfo() {
+
+    }
+
+    // 특정 박람회 정보 수정
+    @PutMapping("/expos/{expoId}")
+    public ResponseEntity<ExpoResponseDto> updateExpoInfo() {
+
+    }
+
+    // 특정 박람회 배너 신청
+    @PostMapping("expos/{expoId}/banner")
+    public ResponseEntity<BannerResponseDto> createExpoBanner() {
+
+    }
+
+    // 특정 박람회 배너 조회
+    @GetMapping("expos/{expoId}/banner")
+    public ResponseEntity<BannerResponseDto> findExpoBanner() {
+
+    }
+
+    // 특정 박람회 배너 수정
+    @PutMapping("expos/{expoId}/banner")
+    public ResponseEntity<BannerResponseDto> updateExpoBanner() {
+
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerCreateRequestDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerCreateRequestDto.java
@@ -1,0 +1,33 @@
+package com.eventory.expoAdmin.dto;
+
+import com.eventory.common.entity.BannerStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BannerCreateRequestDto {
+    @NotNull
+    @Positive
+    private Long bannerId;
+
+    @NotBlank
+    private String imageUrl;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+
+    @NotNull
+    private BannerStatus status;
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerCreateRequestDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerCreateRequestDto.java
@@ -15,9 +15,6 @@ import java.time.LocalDate;
 @Builder
 @AllArgsConstructor
 public class BannerCreateRequestDto {
-    @NotNull
-    @Positive
-    private Long bannerId;
 
     @NotBlank
     private String imageUrl;
@@ -27,7 +24,4 @@ public class BannerCreateRequestDto {
 
     @NotNull
     private LocalDate endDate;
-
-    @NotNull
-    private BannerStatus status;
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerResponseDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerResponseDto.java
@@ -1,0 +1,54 @@
+package com.eventory.expoAdmin.dto;
+
+import com.eventory.common.entity.BannerStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BannerResponseDto {
+
+    @NotNull
+    @Positive
+    private Long bannerId;
+
+    @NotNull
+    @Positive
+    private Long expoId;
+
+    @NotNull
+    @Positive
+    private Long paymentId;
+
+    @NotBlank
+    private String imageUrl;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime updatedAt;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+
+    @NotNull
+    private BannerStatus status;
+
+    @NotBlank
+    private String reason;
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerUpdateRequestDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/BannerUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.eventory.expoAdmin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BannerUpdateRequestDto {
+
+    @NotBlank
+    private String imageUrl;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ExpoRequestDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ExpoRequestDto.java
@@ -1,7 +1,5 @@
 package com.eventory.expoAdmin.dto;
 
-import com.eventory.common.entity.ExpoStatus;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -10,15 +8,11 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class ExpoRequestDto {
-    @NotNull
-    @Positive
-    private Long expoId;
 
     @NotBlank
     private String title;

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ExpoRequestDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ExpoRequestDto.java
@@ -1,0 +1,40 @@
+package com.eventory.expoAdmin.dto;
+
+import com.eventory.common.entity.ExpoStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ExpoRequestDto {
+    @NotNull
+    @Positive
+    private Long expoId;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String imageUrl;
+
+    @NotBlank
+    private String description;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotNull
+    private LocalDate endDate;
+
+    @NotNull
+    private Boolean visibility;
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ManagerRequestDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ManagerRequestDto.java
@@ -1,0 +1,21 @@
+package com.eventory.expoAdmin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ManagerRequestDto {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String phone;
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ManagerResponseDto.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/dto/ManagerResponseDto.java
@@ -1,6 +1,5 @@
 package com.eventory.expoAdmin.dto;
 
-import com.eventory.common.entity.ExpoStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,42 +8,28 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
-public class ExpoResponseDto {
-
-    @NotNull
-    @Positive
-    private Long expoId;
+public class ManagerResponseDto {
 
     @NotNull
     @Positive
     private Long expoAdminId;
 
     @NotBlank
-    private String title;
+    private String password;
 
     @NotBlank
-    private String imageUrl;
+    private String name;
 
     @NotBlank
-    private String description;
-
-    @NotNull
-    private LocalDate startDate;
-
-    @NotNull
-    private LocalDate endDate;
+    private String email;
 
     @NotBlank
-    private String location;
-
-    @NotNull
-    private Boolean visibility;
+    private String phone;
 
     @NotNull
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -53,17 +38,4 @@ public class ExpoResponseDto {
     @NotNull
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
-
-    @NotNull
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime displayStartDate;
-
-    @NotNull
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime displayUpdateDate;
-
-    @NotNull
-    private ExpoStatus status;
-
-    private String reason;
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoAdminService.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoAdminService.java
@@ -1,5 +1,6 @@
 package com.eventory.expoAdmin.service;
 
+import com.eventory.common.entity.ExpoAdmin;
 import com.eventory.expoAdmin.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDate;
@@ -7,7 +8,7 @@ import org.springframework.core.io.Resource;
 import java.util.List;
 
 public interface ExpoAdminService {
-    List<ExpoResponseDto> findAllExpos(Long expoAdminId);
+    List<ExpoResponseDto> findAllExpos(ExpoAdmin expoAdmin);
 
     DashboardResponseDto findDashboardSummary(Long expoId);
 

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoAdminServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoAdminServiceImpl.java
@@ -31,10 +31,16 @@ public class ExpoAdminServiceImpl implements ExpoAdminService {
 
     // 해당 박람회 관리자에 속하는 전체 박람회 목록
     @Override
-    public List<ExpoResponseDto> findAllExpos(Long expoAdminId) {
+    public List<ExpoResponseDto> findAllExpos(ExpoAdmin expoAdmin) {
+
+        if (expoAdmin == null || expoAdmin.getExpoAdminId() == null) {
+            throw new CustomException(CustomErrorCode.NOT_FOUND_EXPO_ADMIN);
+        }
+
+        Long expoAdminId = expoAdmin.getExpoAdminId();
 
         // 연관관계 ExpoAdmin의 기본키(expoAdminId)로 Expo 조회 및 제목(title) 오름차순 정렬
-        List<Expo> expos = expoRepository.findByExpoAdmin_ExpoAdminIdOrderByTitleAsc(expoAdminId);
+        List<Expo> expos = expoRepository.findByExpoAdminIdAndStatusOrderByTitleAsc(expoAdminId, ExpoStatus.APPROVED);
 
         // 스트림 각 요소를 dto객체로 변환 후 다시 List로 반환
         return expos.stream()

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoAdminServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoAdminServiceImpl.java
@@ -25,7 +25,6 @@ import java.util.stream.IntStream;
 public class ExpoAdminServiceImpl implements ExpoAdminService {
     private final ExpoRepository expoRepository;
     private final ExpoStatisticsRepository expoStatisticsRepository;
-    private final RefundRepository refundRepository;
     private final ReservationRepository reservationRepository;
     private final CheckInLogRepository checkInLogRepository;
     private final ExpoMapper expoMapper;

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
@@ -4,7 +4,7 @@ import com.eventory.expoAdmin.dto.*;
 import jakarta.validation.Valid;
 
 public interface ExpoInfoService {
-    /*ManagerResponseDto findExpoManagerInfo(Long expoAdminId);
+    ManagerResponseDto findExpoManagerInfo(Long expoAdminId);
 
     void updateExpoManagerInfo(Long expoAdminId, @Valid ManagerRequestDto requestDto);
 
@@ -16,5 +16,5 @@ public interface ExpoInfoService {
 
     BannerResponseDto findExpoBanner(Long expoId);
 
-    void updateExpoBanner(Long expoId, @Valid BannerUpdateRequestDto requestDto);*/
+    void updateExpoBanner(Long expoId, @Valid BannerUpdateRequestDto requestDto);
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
@@ -1,0 +1,4 @@
+package com.eventory.expoAdmin.service;
+
+public interface ExpoInfoService {
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
@@ -4,7 +4,7 @@ import com.eventory.expoAdmin.dto.*;
 import jakarta.validation.Valid;
 
 public interface ExpoInfoService {
-    ManagerResponseDto findExpoManagerInfo(Long expoAdminId);
+    /*ManagerResponseDto findExpoManagerInfo(Long expoAdminId);
 
     void updateExpoManagerInfo(Long expoAdminId, @Valid ManagerRequestDto requestDto);
 
@@ -16,5 +16,5 @@ public interface ExpoInfoService {
 
     BannerResponseDto findExpoBanner(Long expoId);
 
-    void updateExpoBanner(Long expoId, @Valid BannerUpdateRequestDto requestDto);
+    void updateExpoBanner(Long expoId, @Valid BannerUpdateRequestDto requestDto);*/
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoService.java
@@ -1,4 +1,20 @@
 package com.eventory.expoAdmin.service;
 
+import com.eventory.expoAdmin.dto.*;
+import jakarta.validation.Valid;
+
 public interface ExpoInfoService {
+    ManagerResponseDto findExpoManagerInfo(Long expoAdminId);
+
+    void updateExpoManagerInfo(Long expoAdminId, @Valid ManagerRequestDto requestDto);
+
+    ExpoResponseDto findExpoInfo(Long expoId);
+
+    void updateExpoInfo(Long expoId, @Valid ExpoRequestDto requestDto);
+
+    void createExpoBanner(Long expoId, @Valid BannerCreateRequestDto requestDto);
+
+    BannerResponseDto findExpoBanner(Long expoId);
+
+    void updateExpoBanner(Long expoId, @Valid BannerUpdateRequestDto requestDto);
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
@@ -25,7 +25,7 @@ public class ExpoInfoServiceImpl implements ExpoInfoService {
     private final ExpoMapper expoMapper;
 
     // 박람회 담당자 정보 조회
-    @Override
+    /*@Override
     public ManagerResponseDto findExpoManagerInfo(Long expoAdminId) {
         ExpoAdmin expoAdmin = expoAdminRepository.findById(expoAdminId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_MANAGER));
@@ -68,5 +68,5 @@ public class ExpoInfoServiceImpl implements ExpoInfoService {
     @Override
     public void updateExpoBanner(Long expoId, BannerUpdateRequestDto requestDto) {
         Optional<Banner> banner = bannerRepository.findByExpo_ExpoId(expoId);
-    }
+    }*/
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
@@ -1,9 +1,72 @@
 package com.eventory.expoAdmin.service;
 
+import com.eventory.common.entity.Banner;
+import com.eventory.common.entity.Expo;
+import com.eventory.common.entity.ExpoAdmin;
+import com.eventory.common.exception.CustomErrorCode;
+import com.eventory.common.exception.CustomException;
+import com.eventory.common.repository.BannerRepository;
+import com.eventory.common.repository.ExpoAdminRepository;
+import com.eventory.common.repository.ExpoRepository;
+import com.eventory.expoAdmin.dto.*;
+import com.eventory.expoAdmin.service.mapper.ExpoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ExpoInfoServiceImpl implements ExpoInfoService {
+
+    private final ExpoAdminRepository expoAdminRepository;
+    private final ExpoRepository expoRepository;
+    private final BannerRepository bannerRepository;
+    private final ExpoMapper expoMapper;
+
+    // 박람회 담당자 정보 조회
+    @Override
+    public ManagerResponseDto findExpoManagerInfo(Long expoAdminId) {
+        ExpoAdmin expoAdmin = expoAdminRepository.findById(expoAdminId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_MANAGER));
+        return expoMapper.toManagerResponseDto(expoAdmin);
+    }
+
+    // 박람회 담당자 정보 수정
+    @Override
+    public void updateExpoManagerInfo(Long expoAdminId, ManagerRequestDto requestDto) {
+        Optional<ExpoAdmin> expoAdmin = expoAdminRepository.findById(expoAdminId);
+    }
+
+    // 특정 박람회 정보 조회
+    @Override
+    public ExpoResponseDto findExpoInfo(Long expoId) {
+        Optional<Expo> expo = expoRepository.findById(expoId);
+        return null;
+    }
+
+    // 특정 박람회 정보 수정
+    @Override
+    public void updateExpoInfo(Long expoId, ExpoRequestDto requestDto) {
+        Optional<Expo> expo = expoRepository.findById(expoId);
+    }
+
+    // 특정 박람회 배너 신청
+    @Override
+    public void createExpoBanner(Long expoId, BannerCreateRequestDto requestDto) {
+        Optional<Expo> expo = expoRepository.findById(expoId);
+    }
+
+    // 특정 박람회 배너 조회
+    @Override
+    public BannerResponseDto findExpoBanner(Long expoId) {
+        Optional<Banner> banner = bannerRepository.findByExpo_ExpoId(expoId);
+        return null;
+    }
+
+    // 특정 박람회 배너 수정
+    @Override
+    public void updateExpoBanner(Long expoId, BannerUpdateRequestDto requestDto) {
+        Optional<Banner> banner = bannerRepository.findByExpo_ExpoId(expoId);
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
@@ -13,8 +13,6 @@ import com.eventory.expoAdmin.service.mapper.ExpoMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class ExpoInfoServiceImpl implements ExpoInfoService {
@@ -25,48 +23,77 @@ public class ExpoInfoServiceImpl implements ExpoInfoService {
     private final ExpoMapper expoMapper;
 
     // 박람회 담당자 정보 조회
-    /*@Override
+    @Override
     public ManagerResponseDto findExpoManagerInfo(Long expoAdminId) {
+
         ExpoAdmin expoAdmin = expoAdminRepository.findById(expoAdminId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_MANAGER));
+
         return expoMapper.toManagerResponseDto(expoAdmin);
     }
 
     // 박람회 담당자 정보 수정
     @Override
     public void updateExpoManagerInfo(Long expoAdminId, ManagerRequestDto requestDto) {
-        Optional<ExpoAdmin> expoAdmin = expoAdminRepository.findById(expoAdminId);
+
+        ExpoAdmin expoAdmin = expoAdminRepository.findById(expoAdminId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_MANAGER));
+
+        expoAdmin.updateExpoAdmin(requestDto);
+
+        expoAdminRepository.save(expoAdmin);
     }
 
     // 특정 박람회 정보 조회
     @Override
     public ExpoResponseDto findExpoInfo(Long expoId) {
-        Optional<Expo> expo = expoRepository.findById(expoId);
-        return null;
+
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_EXPO));
+
+        return expoMapper.toExpoResponseDto(expo);
     }
 
     // 특정 박람회 정보 수정
     @Override
     public void updateExpoInfo(Long expoId, ExpoRequestDto requestDto) {
-        Optional<Expo> expo = expoRepository.findById(expoId);
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_EXPO));
+
+        expo.updateExpo(requestDto);
+
+        expoRepository.save(expo);
     }
 
     // 특정 박람회 배너 신청
     @Override
     public void createExpoBanner(Long expoId, BannerCreateRequestDto requestDto) {
-        Optional<Expo> expo = expoRepository.findById(expoId);
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_EXPO));
+
+        Banner banner = expoMapper.toBannerRequestDto(expo, requestDto);
+
+        bannerRepository.save(banner);
     }
 
     // 특정 박람회 배너 조회
     @Override
     public BannerResponseDto findExpoBanner(Long expoId) {
-        Optional<Banner> banner = bannerRepository.findByExpo_ExpoId(expoId);
-        return null;
+
+        Banner banner = bannerRepository.findByExpo_ExpoId(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_BANNER));
+
+        return expoMapper.toBannerResponseDto(banner);
     }
 
     // 특정 박람회 배너 수정
     @Override
     public void updateExpoBanner(Long expoId, BannerUpdateRequestDto requestDto) {
-        Optional<Banner> banner = bannerRepository.findByExpo_ExpoId(expoId);
-    }*/
+        Banner banner = bannerRepository.findByExpo_ExpoId(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_BANNER));
+
+        banner.updateBanner(requestDto);
+
+        bannerRepository.save(banner);
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/ExpoInfoServiceImpl.java
@@ -1,0 +1,9 @@
+package com.eventory.expoAdmin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExpoInfoServiceImpl implements ExpoInfoService {
+}

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/SalesAdminServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/SalesAdminServiceImpl.java
@@ -257,14 +257,14 @@ public class SalesAdminServiceImpl implements SalesAdminService {
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_REFUND));
 
-        // 요청됨 상태가 아니면 오류 발생
-        if (request.getStatus()!=RefundStatus.PENDING) {
-            throw new CustomException(CustomErrorCode.NOT_FOUND_REFUND);
-        }
-
         // 환불 반려 시 반려 사유 없으면 오류 발생
         if (request.getStatus() == RefundStatus.REJECTED && (request.getReason() == null || request.getReason().isBlank())) {
             throw new CustomException(CustomErrorCode.NOT_FOUND_REASON);
+        }
+
+        // 요청됨 상태라면 오류 발생
+        if (request.getStatus() == RefundStatus.PENDING) {
+            throw new CustomException(CustomErrorCode.NOT_FOUND_REFUND);
         }
 
         // 환불 상태 변경 및 저장

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/SalesAdminServiceImpl.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/SalesAdminServiceImpl.java
@@ -251,24 +251,24 @@ public class SalesAdminServiceImpl implements SalesAdminService {
     // 환불 상태 변경
     @Transactional
     @Override
-    public void updateRefundStatus(Long refundId, RefundRequestDto request) {
+    public void updateRefundStatus(Long refundId, RefundRequestDto requestDto) {
 
         // 환불(refundId) 조회
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_REFUND));
 
         // 환불 반려 시 반려 사유 없으면 오류 발생
-        if (request.getStatus() == RefundStatus.REJECTED && (request.getReason() == null || request.getReason().isBlank())) {
+        if (requestDto.getStatus() == RefundStatus.REJECTED && (requestDto.getReason() == null || requestDto.getReason().isBlank())) {
             throw new CustomException(CustomErrorCode.NOT_FOUND_REASON);
         }
 
         // 요청됨 상태라면 오류 발생
-        if (request.getStatus() == RefundStatus.PENDING) {
+        if (requestDto.getStatus() == RefundStatus.PENDING) {
             throw new CustomException(CustomErrorCode.NOT_FOUND_REFUND);
         }
 
         // 환불 상태 변경 및 저장
-        refund.updateStatus(refund.getStatus(), refund.getReason());
+        refund.updateStatus(requestDto);
         refundRepository.save(refund);
     }
 

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/mapper/ExpoMapper.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/mapper/ExpoMapper.java
@@ -121,4 +121,7 @@ public class ExpoMapper {
                 .percentage(percentage)
                 .build();
     }
+
+    public ManagerResponseDto toManagerResponseDto(ExpoAdmin expoAdmin) {
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/mapper/ExpoMapper.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/mapper/ExpoMapper.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Component
 @AllArgsConstructor
@@ -21,11 +22,18 @@ public class ExpoMapper {
                 .expoId(expo.getExpoId())
                 .expoAdminId(expo.getExpoAdmin().getExpoAdminId())
                 .title(expo.getTitle())
+                .imageUrl(expo.getImageUrl())
                 .description(expo.getDescription())
                 .startDate(expo.getStartDate())
                 .endDate(expo.getEndDate())
                 .location(expo.getLocation())
                 .visibility(expo.getVisibility())
+                .createdAt(expo.getCreatedAt())
+                .updatedAt(expo.getUpdatedAt())
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayUpdateDate(expo.getDisplayUpdateDate())
+                .status(expo.getStatus())
+                .reason(expo.getReason())
                 .build();
     }
 
@@ -122,6 +130,41 @@ public class ExpoMapper {
                 .build();
     }
 
-    /*public ManagerResponseDto toManagerResponseDto(ExpoAdmin expoAdmin) {
-    }*/
+    public ManagerResponseDto toManagerResponseDto(ExpoAdmin expoAdmin) {
+        return ManagerResponseDto.builder()
+                .expoAdminId(expoAdmin.getExpoAdminId())
+                .password(expoAdmin.getPassword())
+                .name(expoAdmin.getName())
+                .email(expoAdmin.getEmail())
+                .phone(expoAdmin.getPhone())
+                .createdAt(expoAdmin.getCreatedAt())
+                .updatedAt(expoAdmin.getUpdatedAt())
+                .build();
+    }
+
+    public Banner toBannerRequestDto(Expo expo, BannerCreateRequestDto requestDto) {
+        return Banner.builder()
+                .expo(expo)
+                .payment(null)
+                .imageUrl(requestDto.getImageUrl())
+                .startDate(requestDto.getStartDate())
+                .endDate(requestDto.getEndDate())
+                .status(BannerStatus.PENDING)
+                .build();
+    }
+
+    public BannerResponseDto toBannerResponseDto(Banner banner) {
+        return BannerResponseDto.builder()
+                .bannerId(banner.getBannerId())
+                .expoId(banner.getExpo().getExpoId())
+                .paymentId(banner.getPayment().getPaymentId())
+                .imageUrl(banner.getImageUrl())
+                .createdAt(banner.getCreatedAt())
+                .updatedAt(banner.getUpdatedAt())
+                .startDate(banner.getStartDate())
+                .endDate(banner.getEndDate())
+                .status(banner.getStatus())
+                .reason(banner.getReason())
+                .build();
+    }
 }

--- a/eventory-server/src/main/java/com/eventory/expoAdmin/service/mapper/ExpoMapper.java
+++ b/eventory-server/src/main/java/com/eventory/expoAdmin/service/mapper/ExpoMapper.java
@@ -122,6 +122,6 @@ public class ExpoMapper {
                 .build();
     }
 
-    public ManagerResponseDto toManagerResponseDto(ExpoAdmin expoAdmin) {
-    }
+    /*public ManagerResponseDto toManagerResponseDto(ExpoAdmin expoAdmin) {
+    }*/
 }


### PR DESCRIPTION
- 후 결제 기능 : payment_id null값 허용으로 변경
- Expo Entity에 ExpoAdminId null값 허용으로 변경
- RequestBody에 @Valid 추가
- 해당 박람회 관리자에 속하는 전체 박람회 목록 : ExpoStatus.APPROVED만 가져오는 걸로 변경
- 박람회 담당자 정보 조회, 수정 : findExpoManagerInfo, updateExpoManagerInfo
- 특정 박람회 정보 조회,수정 : findExpoInfo, updateExpoInfo
- 특정 박람회 배너 신청, 조회, 수정 : createExpoBanner, findExpoBanner, updateExpoBanner